### PR TITLE
local pose used for EstimateFeatureMapQualityForHosting

### DIFF
--- a/Runtime/Scripts/ARAnchorManagerExtensions.cs
+++ b/Runtime/Scripts/ARAnchorManagerExtensions.cs
@@ -364,7 +364,8 @@ namespace Google.XR.ARCoreExtensions
 
         /// <summary>
         /// Estimates the quality of the visual feature points seen by ARCore in the
-        /// preceding few seconds and visible from the provided camera <paramref name="pose"/>.
+        /// preceding few seconds and visible from the provided camera <paramref name="pose"/>
+        /// relative to the session origin.
         /// Cloud Anchors hosted using higher feature map quality will generally result
         /// in easier and more accurately resolved <c><see cref="ARCloudAnchor"/></c> poses.
         /// If feature map quality cannot be estimated for the given <paramref name="pose"/>,

--- a/Samples~/PersistentCloudAnchors/Scripts/ARViewManager.cs
+++ b/Samples~/PersistentCloudAnchors/Scripts/ARViewManager.cs
@@ -195,8 +195,8 @@ namespace Google.XR.ARCoreExtensions.Samples.PersistentCloudAnchors
         /// <returns>The camera pose of the current frame.</returns>
         public Pose GetCameraPose()
         {
-            return new Pose(Controller.MainCamera.transform.position,
-                Controller.MainCamera.transform.rotation);
+            return new Pose(Controller.MainCamera.transform.localPosition,
+                Controller.MainCamera.transform.localRotation);
         }
 
         /// <summary>


### PR DESCRIPTION
Updated documentation and sample usage for `EstimateFeatureMapQualityForHosting`.

The issue is that the documentation doesnt specify and the sample uses the global pose of the camera. But actually the local pose is expected. This hasn't been an issue in the sample, because the AR Session Origin is at (0,0,0). This is very common, but there are use-cases where the Session Origin has to be moved, which would break the sample when using `EstimateFeatureMapQualityForHosting`.

