### PR TITLE
Fix native collection memory leak in ARCoreAnalytics

### DIFF
--- a/Editor/Scripts/Internal/ARCoreAnalytics.cs
+++ b/Editor/Scripts/Internal/ARCoreAnalytics.cs
@@ -128,6 +128,7 @@ namespace Google.XR.ARCoreExtensions.Editor.Internal
             {
                 if (_webRequest.isDone == true)
                 {
+                    _webRequest.uploadHandler.Dispose();
                     _webRequest = null;
                 }
             }

--- a/Editor/Scripts/Internal/ARCoreAnalytics.cs
+++ b/Editor/Scripts/Internal/ARCoreAnalytics.cs
@@ -128,7 +128,7 @@ namespace Google.XR.ARCoreExtensions.Editor.Internal
             {
                 if (_webRequest.isDone == true)
                 {
-                    _webRequest.uploadHandler.Dispose();
+                    _webRequest.Dispose();
                     _webRequest = null;
                 }
             }


### PR DESCRIPTION
Fixes #79 

Turns out this one is pretty simple. I encountered this issue in Unity 2021.3.0f1, and after making this change I'm not seeing the error anymore. I think the `UploadHandlerRaw` class started using native collections somewhere along the way and now needs to be explicitly disposed. I will work on updating our docs to make this more clear.

I considered a null check on the upload handler (`_webRequest.uploadHandler?.Dispose`) in case there's some edge case where it's null but I don't think that's necessary.