### PR TITLE
Fix an issue where the project settings for ARCore Extensions are not saved when using Unity 2021.2 or earlier

### DIFF
--- a/Editor/Scripts/Internal/GeospatialEditorHelper.cs
+++ b/Editor/Scripts/Internal/GeospatialEditorHelper.cs
@@ -109,7 +109,10 @@ namespace Google.XR.ARCoreExtensions.Editor.Internal
                 // disabled if they are present.
             }
 #else // Error state because this is an invalid version of Unity
-            throw new Exception("Geospatial Creator requires Unity 2021.3 or later.");
+            if (toggleChecked)
+            {
+                Debug.LogError("Geospatial Creator requires Unity 2021.3 or later.");
+            }
 #endif
         }
 


### PR DESCRIPTION
In the current implementation, an Exception is thrown and the settings are not saved.
I think it would be preferable to output an error log instead of throwing an Exception.

